### PR TITLE
Prefix notification with "[GitHub]"

### DIFF
--- a/src/event-actions/all.coffee
+++ b/src/event-actions/all.coffee
@@ -26,7 +26,7 @@ buildNewIssueOrPRMessage = (data, eventType, callback) ->
     mentioned_line = ''
     if pr_or_issue.body?
       mentioned_line = extractMentionsFromBody(pr_or_issue.body)
-    callback "New #{eventType.replace('_', ' ')} \"#{pr_or_issue.title}\" by #{pr_or_issue.user.login}: #{pr_or_issue.html_url}#{mentioned_line}"
+    callback "[GitHub] New #{eventType.replace('_', ' ')} \"#{pr_or_issue.title}\" by #{pr_or_issue.user.login}: #{pr_or_issue.html_url}#{mentioned_line}"
 
 module.exports =
   issues: (data, callback) ->
@@ -39,7 +39,7 @@ module.exports =
     build = data.build
     if build?
       if build.status is "built"
-        callback "#{build.pusher.login} built #{data.repository.full_name} pages at #{build.commit} in #{build.duration}ms."
+        callback "[GitHub] #{build.pusher.login} built #{data.repository.full_name} pages at #{build.commit} in #{build.duration}ms."
       if build.error.message?
         callback "Page build for #{data.repository.full_name} errored: #{build.error.message}."
 


### PR DESCRIPTION
In making chat output more parsable, I'm starting for favour a notification format like this

```
hubot>>> [Freshdesk] #449 (☆☆☆) - Ticket created. http://gittip.freshdesk.com/helpdesk/tickets/449
hubot>>> [GitHub] New issue "Gravatar not updating" by wrought: https://github.com/gittip/www.gittip.com/issues/2392
```

Any objection to us taking that approach, @parkr?
