### PR TITLE
Fix typo: synchornized => synchronized

### DIFF
--- a/src/event-actions/all.coffee
+++ b/src/event-actions/all.coffee
@@ -174,7 +174,7 @@ module.exports =
       when "unlabeled"
         msg += " #{sender.login} removed label: \"#{data.label.name}\" "
       when "synchronize"
-        msg +=" synchornized by #{sender.login} "
+        msg +=" synchronized by #{sender.login} "
 
     callback msg + "- #{pull_req.html_url}"
 


### PR DESCRIPTION
Just fixing a simple typo in one of the event handlers.

synchornized => synchronized